### PR TITLE
Bug fix

### DIFF
--- a/R/geomx_import_data.R
+++ b/R/geomx_import_data.R
@@ -160,7 +160,7 @@ geomx_import_fun <- function(countFile, sampleAnnoFile, featureAnnoFile,
       genemeta <- genemeta[rownames(countdata), ]
     }
     else {
-      gene_meta <- data.frame(Type = rep("gene", nrow(countdata)))
+      genemeta <- data.frame(Type = rep("gene", nrow(countdata)))
     }
     
     if (is.data.frame(sampleAnnoFile)) {
@@ -179,7 +179,7 @@ geomx_import_fun <- function(countFile, sampleAnnoFile, featureAnnoFile,
     countdata_lcpm <- edgeR::cpm(countdata, log = TRUE)
     spe <- SpatialExperiment::SpatialExperiment(assays = list(counts = countdata, 
                                                               logcounts = countdata_lcpm), colData = samplemeta, 
-                                                rowData = gene_meta, spatialCoords = as.matrix(samplemeta[, 
+                                                rowData = genemeta, spatialCoords = as.matrix(samplemeta[, 
                                                                                                           coord.colnames]))
   }
   return(spe)


### PR DESCRIPTION
Depending on the conditions, a `genemeta` or `gene_meta` object was created; when it was `genemeta` this resulted in an error because the call to `SpatialExperiment` assumed it was `gene_meta`.